### PR TITLE
Fix templates missing html tags.

### DIFF
--- a/local-template/includes/fragment-pageTable.html
+++ b/local-template/includes/fragment-pageTable.html
@@ -1,4 +1,5 @@
 {% if site.data.pages[page.path].status or site.data.pages[page.path].fmm %}
+<div>
   <table class="{{site.data.pages[page.path].statusclass}}">
     <tr>
       {% if site.data.pages[page.path].status %}

--- a/local-template/includes/fragment-pageend.html
+++ b/local-template/includes/fragment-pageend.html
@@ -55,6 +55,8 @@
   </div>
 </div> -->
 
+</div>
+
 <footer class="shadow-sm" style="background-color: #F3F5F8; padding: 32px 48px;">
   <div class="d-flex flex-wrap justify-content-between w-100" style="margin-bottom: 32px;">
       <div class="d-flex flex-column" style="width: 30%; gap: 32px;">
@@ -85,7 +87,7 @@
         <div class="d-flex flex-column" style="width: 60%; gap: 16px">
           <p style="font-family: inter; font-weight: 600; font-size: 14px; color: black; margin: 0px;">Connect with us</p>
           <button class="d-flex flex-row justify-content-center align-items-center" style="min-width: 200px; gap: 8px; font-family: inter; font-weight: 600; font-size: 16px; color: black; background-color: white; border: none; border-radius: 8px; height: 44px;">
-            <div>
+            <div class="d-flex">
               <svg width="20" height="22" viewBox="0 0 20 22" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <rect y="0.654297" width="20" height="20.6897" fill="url(#pattern0_4363_1891)"/>
               <defs>
@@ -102,7 +104,7 @@
           </button>
 
           <button class="d-flex flex-row justify-content-center align-items-center" style="min-width: 200px; gap: 8px; font-family: inter; font-weight: 600; font-size: 16px; color: black; background-color: white; border: none; border-radius: 8px; height: 44px;">
-            <div>
+            <div class="d-flex">
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0ZM9.50621 9.23611L5.92092 12.4376C5.55159 12.7282 5.30926 13.2079 5.30926 13.7475C5.30926 14.6286 5.95564 15.3496 6.74566 15.3496H13.4837C14.2737 15.3496 14.9201 14.6286 14.9201 13.7475C14.9201 12.8661 14.2737 12.1453 13.4837 12.1453H8.38278C8.30715 12.1453 8.25935 12.0547 8.29621 11.981L9.61133 9.34788C9.65937 9.27106 9.5728 9.17903 9.50621 9.23611ZM13.4837 4.63772H6.74566C5.95564 4.63772 5.30926 5.35853 5.30926 6.23988C5.30926 7.12098 5.95564 7.84204 6.74566 7.84204H11.8465C11.9222 7.84204 11.97 7.93264 11.9331 8.00637L10.618 10.6395C10.57 10.7163 10.6565 10.8083 10.7231 10.7512L14.3084 7.54929C14.6777 7.25844 14.9201 6.779 14.9201 6.2394C14.9201 5.3583 14.2737 4.63724 13.4837 4.63772Z" fill="url(#paint0_linear_4363_1898)"/>
                 <defs>


### PR DESCRIPTION
- Add the missing opening <div> tag for pageTable.
- Ensure a definite closing </div> tag for pageBegin's main-section.
- Correct the alignment issue with the "Connect with us" icons.