### PR TITLE
Disable shrinking on header and footer.

### DIFF
--- a/local-template/includes/fragment-pagebegin.html
+++ b/local-template/includes/fragment-pagebegin.html
@@ -120,7 +120,7 @@
         </style>
         
         <header class="d-flex justify-content-between align-items-center position-sticky top-0 w-100 bg-white" 
-               style="height: 50px; padding: 36px 48px; border: 1px solid #E7EBF1; z-index: 1000; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);">
+               style="min-width: 1212px; height: 50px; padding: 36px 48px; border: 1px solid #E7EBF1; z-index: 1000; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);">
           <div class="d-flex align-items-center gap-2" style="min-width: 25%;">
             <div class="dropdown">
               <button class="btn btn-secondary bg-white text-dark" type="button" 

--- a/local-template/includes/fragment-pageend.html
+++ b/local-template/includes/fragment-pageend.html
@@ -57,7 +57,7 @@
 
 </div>
 
-<footer class="shadow-sm" style="background-color: #F3F5F8; padding: 32px 48px;">
+<footer class="shadow-sm" style="background-color: #F3F5F8; padding: 32px 48px; min-width: 1212px;">
   <div class="d-flex flex-wrap justify-content-between w-100" style="margin-bottom: 32px;">
       <div class="d-flex flex-column" style="width: 30%; gap: 32px;">
           <div class="d-flex align-items-center">


### PR DESCRIPTION
Set a minimum width for the header and footer to prevent them from shrinking when the window size changes.