### PR TITLE
Fix mobile's sidebar state issue + Migrate header's CSS pseudo-elements to an actual DOM.

### DIFF
--- a/local-template/content/assets/js/searchable-headings.js
+++ b/local-template/content/assets/js/searchable-headings.js
@@ -1,0 +1,115 @@
+/**
+ * Searchable Headings - Makes document heading numbers searchable in browsers
+ * 
+ * Replaces CSS Pseudo counter-based heading numbers with actual DOM elements,
+ * maintaining the same visual appearance but making them searchable.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const config = {
+    headingSelectors: ['h2', 'h3', 'h4', 'h5', 'h6'],
+    numberColor: 'silver',
+    numberClass: 'heading-number',
+    processedClass: 'js-numbered'
+  };
+  
+  const headingProcessor = (() => {
+    let counters = {
+      section: 0,
+      subSection: 0,
+      composite: 0,
+      detail: 0,
+      moreDetail: 0
+    };
+    
+    const resetChildCounters = level => {
+      if (level <= 1) counters.subSection = 0;
+      if (level <= 2) counters.composite = 0;
+      if (level <= 3) counters.detail = 0;
+      if (level <= 4) counters.moreDetail = 0;
+    };
+    
+    return {
+      processHeading: (heading, basePrefix) => {
+        const level = parseInt(heading.tagName.charAt(1));
+        
+        let number = '';
+        switch (level) {
+          case 2:
+            counters.section++;
+            resetChildCounters(1);
+            number = basePrefix;
+            break;
+          case 3:
+            counters.subSection++;
+            resetChildCounters(2);
+            number = `${basePrefix}.${counters.subSection}`;
+            break;
+          case 4:
+            counters.composite++;
+            resetChildCounters(3);
+            number = `${basePrefix}.${counters.subSection}.${counters.composite}`;
+            break;
+          case 5:
+            counters.detail++;
+            resetChildCounters(4);
+            number = `${basePrefix}.${counters.subSection}.${counters.composite}.${counters.detail}`;
+            break;
+          case 6:
+            counters.moreDetail++;
+            number = `${basePrefix}.${counters.subSection}.${counters.composite}.${counters.detail}.${counters.moreDetail}`;
+            break;
+        }
+        
+        return number;
+      }
+    };
+  })();
+
+  const getBasePrefix = () => {
+    try {
+      const h2El = document.querySelector('h2') || document.createElement('h2');
+      const style = window.getComputedStyle(h2El);
+      const cssPrefix = style.getPropertyValue('--heading-prefix');
+      
+      if (cssPrefix && cssPrefix.trim()) {
+        return cssPrefix.replace(/['"[\]]/g, '').trim();
+      }
+      
+      const headingOffset = document.querySelector('meta[name="heading-offset"]')?.content || '';
+      const label = document.querySelector('meta[name="label"]')?.content || '';
+      
+      return (headingOffset + label).replace(/['"[\]]/g, '').trim() || '1';
+    } catch (e) {
+      console.warn('Error getting heading prefix:', e);
+      return '1';
+    }
+  };
+  
+  const processHeadings = () => {
+    const basePrefix = getBasePrefix();
+    
+    const style = document.createElement('style');
+    style.textContent = config.headingSelectors
+      .map(selector => `${selector}.${config.processedClass}:before { content: none !important; }`)
+      .join('\n');
+    document.head.appendChild(style);
+    
+    const headings = document.querySelectorAll(config.headingSelectors.join(','));
+    
+    headings.forEach(heading => {
+      if (heading.classList.contains(config.processedClass)) return;
+      
+      const prefix = headingProcessor.processHeading(heading, basePrefix);
+      
+      const span = document.createElement('span');
+      span.className = config.numberClass;
+      span.style.color = config.numberColor;
+      span.textContent = prefix + ' ';
+      
+      heading.insertBefore(span, heading.firstChild);
+      heading.classList.add(config.processedClass);
+    });
+  };
+  
+  processHeadings();
+});

--- a/local-template/content/assets/js/sidebar-menu.js
+++ b/local-template/content/assets/js/sidebar-menu.js
@@ -1,6 +1,34 @@
 document.addEventListener('DOMContentLoaded', function() {
   const menuToggles = document.querySelectorAll('[data-bs-toggle="collapse"]');
   
+  function syncMenuStates() {
+    menuToggles.forEach(toggle => {
+      const submenuSelector = toggle.getAttribute('href');
+      if (!submenuSelector || !submenuSelector.startsWith('#')) return;
+      
+      const submenuId = submenuSelector.substring(1);
+      const submenu = document.getElementById(submenuId);
+      const chevron = toggle.querySelector('svg');
+      
+      if (!submenu || !chevron) return;
+      
+      const storageKey = `menu-${submenuId}-state`;
+      const isExpanded = localStorage.getItem(storageKey) === 'open';
+      
+      if (isExpanded) {
+        submenu.classList.add('show');
+        chevron.style.transform = 'rotate(90deg)';
+      } else {
+        submenu.classList.remove('show');
+        chevron.style.transform = 'rotate(0deg)';
+      }
+    });
+  }
+  
+  syncMenuStates();
+  
+  window.addEventListener('resize', syncMenuStates);
+  
   menuToggles.forEach(toggle => {
     const submenuSelector = toggle.getAttribute('href');
     if (!submenuSelector || !submenuSelector.startsWith('#')) return;
@@ -28,8 +56,16 @@ document.addEventListener('DOMContentLoaded', function() {
       const willBeExpanded = !submenu.classList.contains('show');
       
       chevron.style.transform = willBeExpanded ? 'rotate(90deg)' : 'rotate(0deg)';
-      
       localStorage.setItem(storageKey, willBeExpanded ? 'open' : 'closed');
+      
+      document.querySelectorAll(`[href="#${submenuId}"]`).forEach(otherToggle => {
+        if (otherToggle !== toggle) {
+          const otherChevron = otherToggle.querySelector('svg');
+          if (otherChevron) {
+            otherChevron.style.transform = willBeExpanded ? 'rotate(90deg)' : 'rotate(0deg)';
+          }
+        }
+      });
     });
   });
   
@@ -83,5 +119,12 @@ document.addEventListener('DOMContentLoaded', function() {
     applySelectedStyling(filename);
   } else if (savedMenuItem) {
     applySelectedStyling(savedMenuItem);
+  }
+  
+  const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
+  if (mobileMenuToggle) {
+    mobileMenuToggle.addEventListener('click', function() {
+      setTimeout(syncMenuStates, 100);
+    });
   }
 });

--- a/local-template/includes/fragment-pagebegin.html
+++ b/local-template/includes/fragment-pagebegin.html
@@ -28,6 +28,9 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="author" content="http://hl7.org/fhir"/>
+    <meta name="heading-offset" content="{{site.data.info.headingOffset}}">
+    <meta name="label" content="{{label}}">
+    <meta name="page-label" content="{{site.data.pages[page.path].label}}">
 
     <link href="{{site.data.info.assets}}fhir.css" rel="stylesheet"/>
 
@@ -159,6 +162,7 @@
 
     <script type="text/javascript" src="fhir-table-scripts.js"> </script>
     <script type="text/javascript" src="{{site.data.info.assets}}assets/js/table-content-scroll.js"> </script>
+    <script type="text/javascript" src="{{site.data.info.assets}}assets/js/searchable-headings.js"></script>
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/local-template/includes/template-page.html
+++ b/local-template/includes/template-page.html
@@ -1,10 +1,5 @@
 {% include fragment-pagebegin.html %}
 <style type="text/css">
-h2:before{color:silver;counter-increment:section;content:var(--heading-prefix) " ";}
-h3:before{color:silver;counter-increment:sub-section;content:var(--heading-prefix) "." counter(sub-section) " ";}
-h4:before{color:silver;counter-increment:composite;content:var(--heading-prefix) "." counter(sub-section) "." counter(composite) " ";}
-h5:before{color:silver;counter-increment:detail;content:var(--heading-prefix) "." counter(sub-section) "." counter(composite) "." counter(detail) " ";}
-h6:before{color:silver;counter-increment:more-detail;content:var(--heading-prefix) "." counter(sub-section) "." counter(composite) "." counter(detail) "." counter(more-detail)" ";}
 </style>
 <div class="col-12">
 


### PR DESCRIPTION
- Resolve mobile sidebar state sync issue, when initial opening is from the desktop version.
- Replace CSS pseudo-element-based heading numbers with actual elements for browser searchability, preserving visual style. Uses a JS-based approach for now to avoid broad content changes required by a Jekyll-based solution.