### PR TITLE
Initial RTL support

### DIFF
--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -1,41 +1,42 @@
+{% assign lang_context = site.data.languages.ig | default: "en" %}
 <ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
-  <li><a href="index.html">IG Home</a></li>
-  <li><a href="toc.html">Table of Contents</a></li>
+  <li><a href="index.html">{{ site.data.locales[lang_context].menu.home | default: "IG Home" }}</a></li>
+  <li><a href="toc.html">{{ site.data.locales[lang_context].menu.toc | default: "Table of Contents" }}</a></li>
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">MyIg Background<b class="caret">
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">{{ site.data.locales[lang_context].menu.background_dropdown | default: "MyIg Background" }}<b class="caret">
       </b>
     </a>
     <ul class="dropdown-menu">
       <li>
-        <a href="background.html">Background</a>
+        <a href="background.html">{{ site.data.locales[lang_context].menu.background_link | default: "Background" }}</a>
       </li>
     </ul>
   </li>
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Specification<b class="caret">
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">{{ site.data.locales[lang_context].menu.specification_dropdown | default: "Specification" }}<b class="caret">
       </b>
     </a>
     <ul class="dropdown-menu">
       <li>
-        <a href="spec.html">Detailed Specification</a>
+        <a href="spec.html">{{ site.data.locales[lang_context].menu.specification_link | default: "Detailed Specification" }}</a>
       </li>
       <li>
-        <a href="fragments.html">Instance Fragments</a>
+        <a href="fragments.html">{{ site.data.locales[lang_context].menu.fragments_link | default: "Instance Fragments" }}</a>
       </li>
     </ul>
   </li>
-  <li><a href="artifacts.html">Artifact Index</a></li>
+  <li><a href="artifacts.html">{{ site.data.locales[lang_context].menu.artifacts | default: "Artifact Index" }}</a></li>
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Support<b class="caret">
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">{{ site.data.locales[lang_context].menu.support_dropdown | default: "Support" }}<b class="caret">
       </b>
     </a>
     <ul class="dropdown-menu">
       <li>
-        <a target="_blank" href="{{site.data.fhir.path}}index.html">FHIR Spec <img src="external.png" style="text-align: baseline"/></a>
+        <a target="_blank" href="{{site.data.fhir.path}}index.html">{{ site.data.locales[lang_context].menu.fhir_spec_link | default: "FHIR Spec" }} <img src="external.png" style="text-align: baseline"/></a>
       </li>
       <li>
-        <a href="downloads.html">Downloads</a>
+        <a href="downloads.html">{{ site.data.locales[lang_context].menu.downloads_link | default: "Downloads" }}</a>
       </li>
     </ul>
   </li>
-</ul>      
+</ul>

--- a/input/myig.xml
+++ b/input/myig.xml
@@ -2,6 +2,11 @@
 <!-- Start by finding all references to "myig" and updating to appropriate text for your IG, including changing realm -->
 <ImplementationGuide xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../input-cache/schemas/R4/fhir-single.xsd">
   <id value="example.fhir.uv.myig"/>
+
+  <!-- Accessible during Jekyll’s build process as: site.data.languages.ig -->
+  <!-- Use this to change the language of the IG template -->
+  <language value="en"/> 
+
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
     <valueCode value="informative"/> 
   </extension> 
@@ -245,6 +250,7 @@
       <value value="true"/>
     </parameter>
     <parameter>
+      <!-- Accessible during Jekyll’s build process as: site.data.languages.defLang -->
       <code value="i18n-default-lang"/>
       <value value="en"/>
     </parameter>

--- a/local-template/data/locales/en.yml
+++ b/local-template/data/locales/en.yml
@@ -1,0 +1,12 @@
+menu:
+  home: "IG Home"
+  toc: "Table of Contents"
+  background_dropdown: "MyIG Background"
+  background_link: "Background"
+  specification_dropdown: "Specification"
+  specification_link: "Detailed Specification"
+  fragments_link: "Instance Fragments"
+  artifacts: "Artifact Index"
+  support_dropdown: "Support"
+  fhir_spec_link: "FHIR Spec"
+  downloads_link: "Downloads"

--- a/local-template/data/locales/fa.yml
+++ b/local-template/data/locales/fa.yml
@@ -1,0 +1,18 @@
+menu:
+  home: "صفحه‌ی اصلی راهنما"
+  toc: "فهرست مطالب"
+  background_dropdown: "‌پیشینه‌ی MyIG"
+  background_link: "پیشینه"
+  specification_dropdown: "مشخصات"
+  specification_link: "مشخصات تفصیلی"
+  fragments_link: "قطعات نمونه"
+  artifacts: "فهرست محصولات"
+  support_dropdown: "پشتیبانی"
+  fhir_spec_link: "مشخصات FHIR"
+  downloads_link: "دانلودها"
+buttons:
+  search: "جستجو"
+  previous: "قبلی"
+  next: "بعدی"
+  top: "بالا"
+language_name: "فارسی"

--- a/local-template/data/locales/fr.yml
+++ b/local-template/data/locales/fr.yml
@@ -1,0 +1,12 @@
+menu:
+  home: "Accueil IG"
+  toc: "Table des Matières"
+  background_dropdown: "Contexte MyIG"
+  background_link: "Contexte"
+  specification_dropdown: "Spécification"
+  specification_link: "Spécification Détaillée"
+  fragments_link: "Fragments d'Instance"
+  artifacts: "Index des Artefacts"
+  support_dropdown: "Support"
+  fhir_spec_link: "Spécification FHIR"
+  downloads_link: "Téléchargements"

--- a/local-template/includes/fragment-pagebegin.html
+++ b/local-template/includes/fragment-pagebegin.html
@@ -1,10 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE HTML>
-<html xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" lang="en">
+{% assign current_lang = site.data.languages.ig | default: "en" %}
+
+{% assign rtl_languages = "ar,he,fa,ur" | split: "," %}
+{% assign is_rtl = false %}
+{% for rtl_lang in rtl_languages %}
+  {% if current_lang == rtl_lang %}
+    {% assign is_rtl = true %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
+
+<html xml:lang="{{ current_lang }}" xmlns="http://www.w3.org/1999/xhtml" lang="{{ current_lang }}"  {% if is_rtl %}dir="rtl"{% endif %}>
   <head>
+    {% if current_lang == "fa" %}
+    <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    {% endif %}
+
     <style>
       * {
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif !important;
+
+      {% if is_rtl %}
+      direction: rtl;
+      text-align: right;
+      {% endif %}
+      }
+
+      :lang(fa) {
+        font-family: 'Vazirmatn', 'Vazir', 'Tahoma', 'Arial Unicode MS', sans-serif !important;
       }
 
       .anchorjs-link {


### PR DESCRIPTION
- Use 'language' value in myig.xml to set the desired language.
- Dynamically enable initial RTL language support based on the language defined in the myig.xml file.
- Enable support for the Persian Vazir font in Chrome, Safari, and Firefox, conditionally loading it only when the selected language is 'fa'.
- Dynamically populate menu.xml items using fa.xml, fr.xml, or en.xml, based on the language specified in myig.xml.